### PR TITLE
fix syntax error due to additional curly brace

### DIFF
--- a/R/add_gnomAD_AF.R
+++ b/R/add_gnomAD_AF.R
@@ -57,7 +57,6 @@ add_gnomAD_AF <- function(data,
   # Compute the MAX_AF (why do we change col names?)
   if(any(c("AF", "AF_popmax") %in% colnames(res))){
     res$MAX_AF <- apply(res[, ..populations], 1, max, na.rm = T)
-    }
     
     # Replace Inf with NA
     res[is.infinite(MAX_AF), MAX_AF := NA]


### PR DESCRIPTION
The curly brace on line 60 is ending the scope early which causes a syntax error on the next one on line 65. 